### PR TITLE
docs: Update the sphinx usage guidelines

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "esbonio.sphinx.confDir": ""
+    "esbonio.sphinx.confDir": "${workspaceFolder}"
 }

--- a/guidelines/general.rst
+++ b/guidelines/general.rst
@@ -9,15 +9,13 @@
 
 For projects different *copier* templates are provided.
 Usage is mandatory.
-For the installation of *copier*, refer to the `official documentation <./https://copier.readthedocs.io/en/latest/>`.
-
-.. warning:: `pip install copier` will install *copier==5.1.0* as of now. Use `pip install copier==v6.0.0b0` instead.
+For the installation of *copier*, refer to the `official documentation <https://copier.readthedocs.io/en/latest/#installation>`_.
 
 Existing templates are:
 
-* `C++ library <../copier-cpp-template>`_
+* `C++ library <https://github.com/deeplex/copier-cpp>`_
 
-Whether you want to create a new project using a template or want to issue a new template, refer to the coding guidelines for your respective language..
+Whether you want to create a new project using a template or want to issue a new template, refer to the coding guidelines for your respective language.
 
 ---------------
  Documentation
@@ -26,29 +24,45 @@ Whether you want to create a new project using a template or want to issue a new
 Documentation is mandatory and missing documentation embarassing.
 The layout for documentation is provided by our *copier* documentation template.
 It is automatically included by all other templates.
-The respective content is created in `docs`.
-
-.. warning:: If the documentation is created using the *copier* script, the `domain <https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html>`_ is not set.
+The respective content is located in the ``docs`` subfolder.
 
 Documentation is generated using `sphinx <https://www.sphinx-doc.org/>`_.
-The `requirements.txt` to install the required packages is provided with the *copier* template for documentation and therefore in the `docs` folder of your project.
-
-Then run (in your project root)
+We use `pipenv <https://pipenv.pypa.io/en/latest/>`_ to manage the required tools to build the documentation and provide language server support for VSCode.
+*pipenv* can be installed with the following command:
 ::
 
-    sphinx-build ./docs /docs/build
+    pip install --user pipenv
 
-To create the documentation.
-Your documentation is generated as `./docs/build/index.html` respectively.
+The ``Pipfile`` to install the required packages is provided with the *copier* template for documentation and therefore in the `docs` folder of your project.
+You need to create the virtual python environment like so:
+::
 
-When using more than one programming language in your project, please update the `conf.py` to include the respective `domain <https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html>`_.
+    cd docs
+    # if you want the esbonio LSP for the reStructuredText VSCode extension
+    pipenv sync --dev
+    # otherwise just
+    pipenv sync
+
+Afterwards you can build the documentation using the commandline tools:
+::
+
+    cd docs
+    pipenv run sphinx-build . ./build
+
+The documentation is generated as `./docs/build/index.html` respectively.
+
+The `reStructuredText VSCode extension <https://marketplace.visualstudio.com/items?itemName=lextudio.restructuredtext>`_ in conjunction with the `MS Python VSCode extension <https://marketplace.visualstudio.com/items?itemName=ms-python.python>`_ can be used to provide language support for ``.rst`` files.
+First you need to connect the extensions to the previously created virtual environment which can be achieved by opening ``conf.py`` and selecting the appropriate `Python interpreter in the status bar <https://github.com/Microsoft/vscode-python#set-up-your-environment>`_.
+Now you can click on the ``Use docutils`` entry in the status bar and set the ``conf.py`` from the ``docs`` folder as the sphinx config to be used.
+
+When using more than one programming language in your project, be sure to include the respective `domain <https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html>`_ in the ``conf.py`` script.
 
 -----------------
  Version control
 -----------------
 
 `git <https://git-scm.com/>`_ has to be used for all projects.
-The `master` (or `main`) branch has to pass all tests at all times.
+The ``master`` (or ``main``) branch has to pass all tests at all times.
 
 To make changes first create an issue in the respective github repository.
 Create a branch using the respective:
@@ -57,25 +71,27 @@ Create a branch using the respective:
 .. image:: /_static/images/github_create_branch_from_issue.png
     :align: center
 
-Prepend `dev/` for your branch name.
-So for example a valid branch name is `dev/1_first_issue`.
-For branches consisting of many issues create an epic issue.
-Refer to GitHub templates for more information.
+Prepend ``dev/`` for your branch name.
+So for example `dev/1-first_issue` would be a valid branch name.
+For branches consisting of many issues create an issue epic.
+Refer to GitHub Issue templates for more information.
 
-.. note:: GitHub templates are automatically generated using *copier* for your project.
+.. note:: GitHub Issue templates are automatically generated using *copier* for your project.
 
 Refer to the guidelines for tests for your respective language.
 
-.. warning:: Every commit has to come with test coverage.
+.. warning:: Every commit has to come with sufficient test coverage.
 
-For *work in progress* commits first check out appending `-wip/<author_name>` to your branch name and do not forget to delete that *wip* branch as soon as it is no longer up to date.
+You may push ``wip/<author_name>/<issue_id>-<description>`` style branches for *work in progress* commits.
+Do not forget to delete your *wip* branch as soon as it becomes outdated.
 
+Commit messages should be structured according to the `Conventional Commits <https://www.conventionalcommits.org/en/v1.0.0/>`_ standard with the `angular type list <https://github.com/angular/angular/blob/48aa96ea13ebfadf/CONTRIBUTING.md#type>`_.
 Always follow `the seven rules of a great Git commit message <https://cbea.ms/git-commit/#seven-rules>`_:
 
-* Separate subject from body with a blank line
-* Limit the subject line to 50 characters
-* Capitalize the subject line
-* Do not end the subject line with a period
-* Use the imperative mood in the subject line
-* Wrap the body at 72 characters
-* Use the body to explain what and why vs. how
+    * Separate subject from body with a blank line
+    * Limit the subject line to about 50 characters
+    * Capitalize the subject line
+    * Do not end the subject line with a period
+    * Use the imperative mood in the subject line
+    * Wrap the body at 72 characters
+    * Use the body to explain the motivitation and constraints of the change


### PR DESCRIPTION
We recently switched to use pipenv to provide documentation/sphinx tooling due to the ease of integration with VSCode.

Also fix various markup issues.